### PR TITLE
ハンドラの引数に`Option[Dict]`を許容するように

### DIFF
--- a/traq_bot/bot.py
+++ b/traq_bot/bot.py
@@ -79,7 +79,7 @@ class TraqBot:
                     func()
                 # もし引数を1つ持っていたら`data`を与えて関数を実行する
                 elif (len(sig.parameters) == 1) and (
-                    next(iter(sig.parameters.values())).annotation in [Dict, _empty]
+                    next(iter(sig.parameters.values())).annotation in [Optional[Dict], Dict, _empty]
                 ):
                     func(data)
                 else:


### PR DESCRIPTION
https://github.com/H1rono/python-traq-bot/blob/92cb243851a4af46b69315bf19479f159edba696/traq_bot/bot.py#L82

https://github.com/H1rono/python-traq-bot/blob/92cb243851a4af46b69315bf19479f159edba696/traq_bot/bot.py#L96-L98

ハンドラ実行時に確認するシグネチャがハンドラ登録のシグネチャと異なっていたため